### PR TITLE
Removed sensitive file and added .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 .DS_Store
 server/public
 vite.config.ts.*
-*.tar.gz
+*.tar.gzconfig/.env


### PR DESCRIPTION
## Summary by Sourcery

Chores:
- Added .env to .gitignore to prevent tracking of environment-specific sensitive files